### PR TITLE
152 preserve initial state

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
+  "eslint.run": "onSave",
   "prettier.enable": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"

--- a/app/ui/sidebar-context/sidebar-provider.test.tsx
+++ b/app/ui/sidebar-context/sidebar-provider.test.tsx
@@ -2,40 +2,144 @@ import { act, render, renderHook, waitFor } from '@testing-library/react';
 import { SidebarProvider } from './sidebar-provider';
 import { use } from 'react';
 import { SidebarContext } from './sidebar-context';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useMediaMock = vi.fn();
+const useLocalStorageMock = vi.fn();
+
+vi.mock('react-use', async () => {
+  const actual = await vi.importActual('react-use');
+  return {
+    ...actual,
+    useMedia: () => useMediaMock(),
+    useLocalStorage: () => useLocalStorageMock(),
+  };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
 
 describe('SidebarProvider', () => {
-  it('should render children', () => {
-    const { getByText, container } = render(
-      <SidebarProvider>child</SidebarProvider>,
-    );
+  describe('rendering and context provision', () => {
+    it('should render children', () => {
+      useMediaMock.mockReturnValue(false);
+      useLocalStorageMock.mockReturnValue([false, vi.fn()]);
 
-    expect(getByText('child')).toBeInTheDocument();
-    expect(container).toMatchInlineSnapshot(`
-      <div>
-        child
-      </div>
-    `);
+      const { getByText, container } = render(
+        <SidebarProvider>child</SidebarProvider>,
+      );
+
+      expect(getByText('child')).toBeInTheDocument();
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          child
+        </div>
+      `);
+    });
+
+    it('should provide isSidebarOpen, setIsSidebarOpen, and triggerRef', () => {
+      useMediaMock.mockReturnValue(false);
+      useLocalStorageMock.mockReturnValue([false, vi.fn()]);
+
+      const { result } = renderHook(() => use(SidebarContext), {
+        wrapper: SidebarProvider,
+      });
+
+      expect(result.current?.isSidebarOpen).toBe(false);
+      expect(result.current?.setIsSidebarOpen).toBeInstanceOf(Function);
+      expect(result.current?.triggerRef).toBeDefined();
+    });
   });
 
-  it('should provide isSidebarOpen and setIsSidebarOpen', () => {
-    const { result } = renderHook(() => use(SidebarContext), {
-      wrapper: SidebarProvider,
+  describe('mobile viewport behavior', () => {
+    beforeEach(() => {
+      useMediaMock.mockReturnValue(false); // mobile
+      useLocalStorageMock.mockReturnValue([true, vi.fn()]);
     });
 
-    expect(result.current?.isSidebarOpen).toBe(false);
-    expect(result.current?.setIsSidebarOpen).toBeInstanceOf(Function);
+    it('should start with sidebar closed on mobile', () => {
+      const { result } = renderHook(() => use(SidebarContext), {
+        wrapper: SidebarProvider,
+      });
+
+      expect(result.current?.isSidebarOpen).toBe(false);
+    });
+
+    it('should allow setting sidebar open on mobile', async () => {
+      const { result } = renderHook(() => use(SidebarContext), {
+        wrapper: SidebarProvider,
+      });
+
+      act(() => {
+        result.current?.setIsSidebarOpen(true);
+      });
+
+      await waitFor(() => {
+        expect(result.current?.isSidebarOpen).toBe(true);
+      });
+    });
+
+    it('should keep mobile state ephemeral (not persist)', async () => {
+      const setDesktopSidebarOpen = vi.fn();
+      useLocalStorageMock.mockReturnValue([true, setDesktopSidebarOpen]);
+
+      const { result } = renderHook(() => use(SidebarContext), {
+        wrapper: SidebarProvider,
+      });
+
+      act(() => {
+        result.current?.setIsSidebarOpen(true);
+      });
+
+      await waitFor(() => {
+        expect(result.current?.isSidebarOpen).toBe(true);
+      });
+
+      // setDesktopSidebarOpen should not be called on mobile
+      expect(setDesktopSidebarOpen).not.toHaveBeenCalled();
+    });
   });
 
-  it('should set isSidebarOpen', async () => {
-    const { result } = renderHook(() => use(SidebarContext), {
-      wrapper: SidebarProvider,
+  describe('desktop viewport behavior', () => {
+    let setDesktopSidebarOpen: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      useMediaMock.mockReturnValue(true); // desktop
+      setDesktopSidebarOpen = vi.fn();
+      useLocalStorageMock.mockReturnValue([true, setDesktopSidebarOpen]);
     });
 
-    act(() => {
-      result.current?.setIsSidebarOpen(true);
+    it('should read persisted desktop state', () => {
+      const { result } = renderHook(() => use(SidebarContext), {
+        wrapper: SidebarProvider,
+      });
+
+      expect(result.current?.isSidebarOpen).toBe(true);
     });
-    await waitFor(() => {
+
+    it('should persist desktop state changes to storage', async () => {
+      const { result } = renderHook(() => use(SidebarContext), {
+        wrapper: SidebarProvider,
+      });
+
+      act(() => {
+        result.current?.setIsSidebarOpen(false);
+      });
+
+      await waitFor(() => {
+        expect(setDesktopSidebarOpen).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it('should normalize non-boolean stored values to true', () => {
+      useLocalStorageMock.mockReturnValue([undefined, setDesktopSidebarOpen]);
+
+      const { result } = renderHook(() => use(SidebarContext), {
+        wrapper: SidebarProvider,
+      });
+
       expect(result.current?.isSidebarOpen).toBe(true);
     });
   });

--- a/app/ui/sidebar-context/sidebar-provider.tsx
+++ b/app/ui/sidebar-context/sidebar-provider.tsx
@@ -1,16 +1,40 @@
-import { useRef, useState, type FC, type PropsWithChildren } from 'react';
+import { useCallback, useRef, useState, type FC, type PropsWithChildren } from 'react';
+import { useLocalStorage, useMedia } from 'react-use';
 import { SidebarContext } from './sidebar-context';
+
+const SIDEBAR_STORAGE_KEY = 'sidebar:is-open';
 
 export const SidebarProvider: FC<PropsWithChildren> = ({
   children,
 }) => {
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const isDesktop = useMedia('(min-width: 1280px)', false);
+  const [desktopSidebarOpen, setDesktopSidebarOpen] = useLocalStorage(
+    SIDEBAR_STORAGE_KEY,
+    true,
+  );
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const normalizedDesktopSidebarOpen = typeof desktopSidebarOpen === 'boolean'
+    ? desktopSidebarOpen
+    : true;
+
+  const isSidebarOpen = isDesktop
+    ? normalizedDesktopSidebarOpen
+    : mobileSidebarOpen;
+
+  const setIsSidebarOpen = useCallback((next: boolean) => {
+    if (isDesktop) {
+      setDesktopSidebarOpen(next);
+      return;
+    }
+
+    setMobileSidebarOpen(next);
+  }, [isDesktop, setDesktopSidebarOpen]);
 
   return (
     <SidebarContext
       value={{
-        isSidebarOpen: isSidebarOpen,
+        isSidebarOpen,
         setIsSidebarOpen,
         triggerRef,
       }}

--- a/app/ui/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/app/ui/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Sidebar > matches the snapshot on desktop 1`] = `
     Toggle
   </button>
   <div
-    class="fixed flex max-w-none sm:max-w-62.5 pointer-events-auto overscroll-y-contain z-20 overflow-hidden w-full pt-14 h-[100dvh] bg-pca-white dark:bg-pca-grey-900"
+    class="fixed flex max-w-none sm:max-w-62.5 pointer-events-auto overscroll-y-contain z-20 overflow-hidden w-full pt-14 h-dvh bg-pca-white dark:bg-pca-grey-900"
     style="transform: none;"
   >
     <nav
@@ -28,7 +28,7 @@ exports[`Sidebar > matches the snapshot on desktop 1`] = `
   </div>
   <div
     class="fixed top-0 left-0 flex flex-col pointer-events-auto z-10 pt-14 h-screen w-16"
-    style="transform: none;"
+    style="transform: translateX(-100%);"
   >
     <nav
       class=" relative flex flex-col grow"

--- a/app/ui/sidebar/sidebar-menu.tsx
+++ b/app/ui/sidebar/sidebar-menu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FC } from 'react';
+import { useState, type FC } from 'react';
 
 import { motion } from 'motion/react';
 import classNames from 'classnames';
@@ -17,18 +17,12 @@ export type SidebarMenuProps = {
 
 export const SidebarMenu: FC<SidebarMenuProps> = ({
   bottomArea,
+  initialState,
   items,
-  initialState = 'close',
   showSlimSidebar = false,
 }) => {
-  const { isSidebarOpen, setIsSidebarOpen } = useSidebarContext();
+  const { isSidebarOpen } = useSidebarContext();
   const [isAnimationComplete, setIsAnimationComplete] = useState(false);
-
-  useEffect(() => {
-    if (initialState === 'open') {
-      setIsSidebarOpen(true);
-    }
-  }, [initialState, setIsSidebarOpen]);
 
   return (
     <>
@@ -38,15 +32,13 @@ export const SidebarMenu: FC<SidebarMenuProps> = ({
         onAnimationComplete={() => setIsAnimationComplete(true)}
         onAnimationStart={() => setIsAnimationComplete(false)}
         exit="close"
-        initial={initialState}
+        initial={initialState ?? (isSidebarOpen ? 'open' : 'close')}
         className={classNames([
-          'fixed flex max-w-none sm:max-w-62.5 pointer-events-auto overscroll-y-contain z-20 overflow-hidden w-full pt-14 h-[100dvh] bg-pca-white dark:bg-pca-grey-900',
+          'fixed flex max-w-none sm:max-w-62.5 pointer-events-auto overscroll-y-contain z-20 overflow-hidden w-full pt-14 h-dvh bg-pca-white dark:bg-pca-grey-900',
           isAnimationComplete && 'transition-shadow ease-in-out duration-200 sm:max-xl:shadow-md sm:max-xl:ring-1 ring-pca-grey-200 sm:max-xl:dark:ring-pca-grey-800',
         ])}
       >
-        <nav
-          className="top-0 left-0 h-[100dvh-56px] flex justify-between flex-col w-full max-w-none sm:max-w-62.5 overflow-hidden overscroll-y-none overflow-x-hidden"
-        >
+        <nav className="top-0 left-0 h-[100dvh-56px] flex justify-between flex-col w-full max-w-none sm:max-w-62.5 overflow-hidden overscroll-y-none overflow-x-hidden">
           <ul className="flex gap-2 flex-col px-1.5 pt-4 grow overflow-scroll scrollbar-none pb-42">
             {items.map(({ key, content }) => {
               return <li key={key}>{content}</li>;

--- a/app/ui/sidebar/sidebar.test.tsx
+++ b/app/ui/sidebar/sidebar.test.tsx
@@ -7,12 +7,19 @@ import { SidebarProvider } from '../sidebar-context/sidebar-provider';
 import { useSidebarContext } from '../sidebar-context/use-sidebar-context';
 import type { SidebarMenuItem } from './types';
 
-const useMedia = vi.fn();
+const useMediaMock = vi.fn();
+const useLocalStorageMock = vi.fn();
 
 vi.mock('react-use', async () => {
   return {
-    useMedia: () => useMedia(),
+    useMedia: () => useMediaMock(),
+    useLocalStorage: () => useLocalStorageMock(),
   };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
 });
 
 const ToggleButton = () => {
@@ -46,7 +53,8 @@ afterEach(() => {
 
 describe('Sidebar', () => {
   it('renders the navigation items open by default on desktop', () => {
-    useMedia.mockReturnValue(true);
+    useMediaMock.mockReturnValue(true);
+    useLocalStorageMock.mockReturnValue([true, () => {}]);
 
     const { getByText } = renderSidebar();
 
@@ -55,7 +63,8 @@ describe('Sidebar', () => {
   });
 
   it('keeps the sidebar closed by default on smaller views', () => {
-    useMedia.mockReturnValue(false);
+    useMediaMock.mockReturnValue(false);
+    useLocalStorageMock.mockReturnValue([false, () => {}]);
 
     const { queryByText } = renderSidebar();
 
@@ -63,7 +72,8 @@ describe('Sidebar', () => {
   });
 
   it('opens the sidebar on smaller views when toggled', async () => {
-    useMedia.mockReturnValue(false);
+    useMediaMock.mockReturnValue(false);
+    useLocalStorageMock.mockReturnValue([false, () => {}]);
 
     const { getByText, findByText } = renderSidebar();
 
@@ -73,7 +83,8 @@ describe('Sidebar', () => {
   });
 
   it('matches the snapshot on desktop', () => {
-    useMedia.mockReturnValue(true);
+    useMediaMock.mockReturnValue(true);
+    useLocalStorageMock.mockReturnValue([true, () => {}]);
 
     const { container } = renderSidebar();
 

--- a/app/ui/sidebar/sidebar.tsx
+++ b/app/ui/sidebar/sidebar.tsx
@@ -14,13 +14,13 @@ export const Sidebar: FC<SidebarProps> = ({
     <SidebarPortal
       mobileChildren={(
         <SidebarMenu
+          initialState="close"
           bottomArea={bottomArea}
           items={items}
         />
       )}
       desktopChildren={(
         <SidebarMenu
-          initialState="open"
           showSlimSidebar
           bottomArea={bottomArea}
           items={items}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
-    "baseUrl": ".",
     "paths": {
       "~/test/*": ["./test/*"],
       "~/*": ["./app/*"]


### PR DESCRIPTION
closes #152 

I researched a bit and decided to use local storage to persist the sidebar UI state. For me, this seems to be more a user preference rather than a volatile value (e.g., a filter setting)

But we can easily switch to session storage if this is not a good idea. I simply used the `react-use` library hook.