### PR TITLE
feat(ui): switch component

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -40,6 +40,7 @@
   --color-pca-orange-700: #D9771E;
   --color-pca-orange-900: #A84C11;
 
+  --color-pca-green-100: #DDFBD0;
   --color-pca-green-300: #A9F58A;
   --color-pca-green-500: #52E01F;
   --color-pca-green-700: #2FA80F;
@@ -97,6 +98,8 @@
 
   --animate-slideRightAndFadeIn: slideRightAndFadeIn 0.15s ease-out;
   --animate-slideRightAndFadeOut: slideRightAndFadeOut 0.15s ease-in;
+
+  --shadow-primary: 0 2px 6px -1px rgba(0,0,0,0.16), 0 1px 4px -1px rgba(0,0,0,0.04);
 
   --shadow-glass: 0 0.5px 1px rgba(0,0,0,0.03), 0 2px 4px rgba(0,0,0,0.03), 0 4px 8px rgba(0,0,0,0.03), 0 8px 16px rgba(0,0,0,0.03), 0 16px 32px rgba(0,0,0,0.03), inset 0 0.5px 0 rgba(255,255,255,0.6);
   --shadow-glass-dark: 0 0.5px 1px rgba(0,0,0,0.12), 0 2px 4px rgba(0,0,0,0.1), 0 4px 8px rgba(0,0,0,0.08), 0 8px 16px rgba(0,0,0,0.08), 0 16px 32px rgba(0,0,0,0.06), inset 0 0.5px 0 rgba(255,255,255,0.06);

--- a/app/components/controlled-switch/__snapshots__/controlled-switch.test.tsx.snap
+++ b/app/components/controlled-switch/__snapshots__/controlled-switch.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`matches snapshot 1`] = `
         aria-hidden="true"
         id="sharing"
         name="sharing"
-        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: absolute;"
         tabindex="-1"
         type="checkbox"
       />

--- a/app/components/controlled-switch/__snapshots__/controlled-switch.test.tsx.snap
+++ b/app/components/controlled-switch/__snapshots__/controlled-switch.test.tsx.snap
@@ -1,0 +1,44 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`matches snapshot 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-2"
+  >
+    <div
+      class="flex gap-2"
+    >
+      <span
+        aria-checked="false"
+        aria-invalid="false"
+        aria-labelledby="sharing-label"
+        class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-pointer bg-pca-grey-400 dark:bg-pca-grey-600 hover:bg-pca-grey-600 dark:hover:bg-pca-grey-800 focus:bg-pca-grey-300 dark:focus:bg-pca-grey-700 focus:ring-2 focus:ring-pca-grey-200 dark:focus:ring-pca-grey-500 data-checked:bg-pca-green-700 data-checked:hover:bg-pca-green-900 data-checked:focus:bg-pca-green-700 data-checked:focus:ring-pca-green-300"
+        data-unchecked=""
+        id="base-ui-_r_1_"
+        role="switch"
+        tabindex="0"
+      >
+        <span
+          class="block size-5 rounded-full shadow-primary transition-transform duration-200 ease-in-out data-checked:translate-x-5 bg-pca-white"
+          data-unchecked=""
+        />
+      </span>
+      <input
+        aria-hidden="true"
+        id="sharing"
+        name="sharing"
+        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        tabindex="-1"
+        type="checkbox"
+      />
+      <label
+        class="antialiased font-inter text-sm text-pca-grey-900 dark:text-pca-grey-300 font-semibold py-0.5 select-none cursor-pointer"
+        for="sharing"
+        id="sharing-label"
+      >
+        Link sharing
+      </label>
+    </div>
+  </div>
+</div>
+`;

--- a/app/components/controlled-switch/controlled-switch.test.tsx
+++ b/app/components/controlled-switch/controlled-switch.test.tsx
@@ -1,0 +1,90 @@
+import { render } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import z from 'zod';
+import { formHook } from '~/hooks/use-app-form';
+import { userEvent } from '@testing-library/user-event';
+
+const schema = z.object({
+  sharing: z.boolean().refine(value => value, {
+    message: 'Link sharing must be enabled',
+  }),
+});
+
+const TestForm: React.FC<{ defaultValue?: boolean }> = ({
+  defaultValue = false,
+}) => {
+  const form = formHook.useAppForm({
+    defaultValues: {
+      sharing: defaultValue,
+    },
+    validators: {
+      onBlur: schema,
+    },
+  });
+
+  return (
+    <form.AppForm>
+      <form.AppField name="sharing">
+        {field => (
+          <field.Switch label="Link sharing" />
+        )}
+      </form.AppField>
+    </form.AppForm>
+  );
+};
+
+test('matches snapshot', () => {
+  const { container } = render(
+    <TestForm />,
+  );
+
+  expect(container).toMatchSnapshot();
+});
+
+test('handles state changes', async () => {
+  const { getByRole } = render(
+    <TestForm />,
+  );
+
+  const element = getByRole('switch');
+
+  await userEvent.click(element);
+  expect(element).toBeChecked();
+
+  await userEvent.click(element);
+  expect(element).not.toBeChecked();
+});
+
+test('renders the value held by the form', () => {
+  const { getByRole } = render(
+    <TestForm defaultValue />,
+  );
+
+  expect(getByRole('switch')).toBeChecked();
+});
+
+test('derives the field name from the form', () => {
+  const { container, getByRole } = render(
+    <TestForm />,
+  );
+
+  expect(getByRole('switch', { name: 'Link sharing' })).toBeInTheDocument();
+
+  // The hidden input is what actually carries the value on submit.
+  const input = container.querySelector('input[type="checkbox"]');
+
+  expect(input).toHaveAttribute('name', 'sharing');
+  expect(input).toHaveAttribute('id', 'sharing');
+});
+
+test('error message', async () => {
+  const { getByRole, getByText } = render(
+    <TestForm defaultValue />,
+  );
+
+  await userEvent.click(getByRole('switch'));
+  await userEvent.tab();
+
+  expect(getByText('Link sharing must be enabled')).toBeInTheDocument();
+  expect(getByRole('switch')).toHaveAttribute('aria-invalid', 'true');
+});

--- a/app/components/controlled-switch/controlled-switch.tsx
+++ b/app/components/controlled-switch/controlled-switch.tsx
@@ -1,0 +1,21 @@
+import { useFieldContext } from '~/contexts/form';
+import { Switch, type SwitchProps } from '~/ui/switch/switch';
+
+export type ControlledSwitchProps = Omit<SwitchProps, 'id' | 'name' | 'checked' | 'onCheckedChange' | 'onBlur' | 'errorMessage'>;
+
+export const ControlledSwitch: React.FC<ControlledSwitchProps>
+  = (props) => {
+    const field = useFieldContext<boolean>();
+
+    return (
+      <Switch
+        id={field.name}
+        name={field.name}
+        checked={field.state.value}
+        onCheckedChange={checked => field.handleChange(checked)}
+        onBlur={field.handleBlur}
+        errorMessage={field.state.meta.errors[0]?.message}
+        {...props}
+      />
+    );
+  };

--- a/app/hooks/use-app-form.ts
+++ b/app/hooks/use-app-form.ts
@@ -5,6 +5,7 @@ import { ControlledCheckbox } from '~/components/controlled-checkbox/controlled-
 import { ControlledHiddenInput } from '~/components/controlled-hidden-input/controlled-hidden-input';
 import { ControlledOneTimePasswordField } from '~/components/controlled-one-time-password-field/controlled-one-time-password-field';
 import { ControlledSubmitButton } from '~/components/controlled-submit-button/controlled-submit-button';
+import { ControlledSwitch } from '~/components/controlled-switch/controlled-switch';
 import { ControlledTextField } from '~/components/controlled-text-field/controlled-text-field';
 import { fieldContext, formContext } from '~/contexts/form';
 
@@ -18,6 +19,7 @@ export const formHook = createFormHook({
   fieldComponents: {
     TextField: ControlledTextField,
     Checkbox: ControlledCheckbox,
+    Switch: ControlledSwitch,
     OneTimePasswordField: ControlledOneTimePasswordField,
     HiddenInput: ControlledHiddenInput,
   },

--- a/app/ui/label/label.tsx
+++ b/app/ui/label/label.tsx
@@ -3,6 +3,7 @@ import type { PropsWithChildren } from 'react';
 
 export interface Label extends PropsWithChildren {
   htmlFor: string;
+  id?: string;
   disabled?: boolean;
   className?: string;
   variant?: TypographyProps['variant'];
@@ -11,6 +12,7 @@ export interface Label extends PropsWithChildren {
 
 export const Label: React.FC<Label>
   = ({ htmlFor,
+    id,
     disabled,
     className,
     variant = 'bodySmall',
@@ -19,6 +21,7 @@ export const Label: React.FC<Label>
   }) => {
     return (
       <Typography
+        id={id}
         htmlFor={htmlFor}
         as="label"
         variant={variant}

--- a/app/ui/switch/__snapshots__/switch.test.tsx.snap
+++ b/app/ui/switch/__snapshots__/switch.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`renders checked state 1`] = `
         aria-labelledby="test-label"
         class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-pointer bg-pca-grey-400 dark:bg-pca-grey-600 hover:bg-pca-grey-600 dark:hover:bg-pca-grey-800 focus:bg-pca-grey-300 dark:focus:bg-pca-grey-700 focus:ring-2 focus:ring-pca-grey-200 dark:focus:ring-pca-grey-500 data-checked:bg-pca-green-700 data-checked:hover:bg-pca-green-900 data-checked:focus:bg-pca-green-700 data-checked:focus:ring-pca-green-300"
         data-checked=""
-        id="base-ui-_r_2_"
+        id="base-ui-_r_3_"
         role="switch"
         tabindex="0"
       >
@@ -27,7 +27,7 @@ exports[`renders checked state 1`] = `
         aria-hidden="true"
         checked=""
         id="test"
-        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
         tabindex="-1"
         type="checkbox"
       />
@@ -59,7 +59,7 @@ exports[`renders disabled checked state 1`] = `
         class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-not-allowed bg-pca-grey-100 dark:bg-pca-grey-800 data-checked:bg-pca-green-100"
         data-checked=""
         data-disabled=""
-        id="base-ui-_r_6_"
+        id="base-ui-_r_9_"
         role="switch"
         tabindex="-1"
       >
@@ -74,7 +74,7 @@ exports[`renders disabled checked state 1`] = `
         checked=""
         disabled=""
         id="test"
-        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
         tabindex="-1"
         type="checkbox"
       />
@@ -106,7 +106,7 @@ exports[`renders disabled state 1`] = `
         class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-not-allowed bg-pca-grey-100 dark:bg-pca-grey-800 data-checked:bg-pca-green-100"
         data-disabled=""
         data-unchecked=""
-        id="base-ui-_r_4_"
+        id="base-ui-_r_6_"
         role="switch"
         tabindex="-1"
       >
@@ -120,7 +120,7 @@ exports[`renders disabled state 1`] = `
         aria-hidden="true"
         disabled=""
         id="test"
-        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
         tabindex="-1"
         type="checkbox"
       />
@@ -151,7 +151,7 @@ exports[`renders error state 1`] = `
         aria-labelledby="test-label"
         class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-pointer bg-pca-grey-400 dark:bg-pca-grey-600 hover:bg-pca-grey-600 dark:hover:bg-pca-grey-800 focus:bg-pca-grey-300 dark:focus:bg-pca-grey-700 focus:ring-2 focus:ring-pca-grey-200 dark:focus:ring-pca-grey-500 data-checked:bg-pca-green-700 data-checked:hover:bg-pca-green-900 data-checked:focus:bg-pca-green-700 data-checked:focus:ring-pca-green-300"
         data-unchecked=""
-        id="base-ui-_r_8_"
+        id="base-ui-_r_c_"
         role="switch"
         tabindex="0"
       >
@@ -163,7 +163,7 @@ exports[`renders error state 1`] = `
       <input
         aria-hidden="true"
         id="test"
-        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
         tabindex="-1"
         type="checkbox"
       />
@@ -200,7 +200,7 @@ exports[`renders hint text 1`] = `
         aria-labelledby="test-label"
         class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-pointer bg-pca-grey-400 dark:bg-pca-grey-600 hover:bg-pca-grey-600 dark:hover:bg-pca-grey-800 focus:bg-pca-grey-300 dark:focus:bg-pca-grey-700 focus:ring-2 focus:ring-pca-grey-200 dark:focus:ring-pca-grey-500 data-checked:bg-pca-green-700 data-checked:hover:bg-pca-green-900 data-checked:focus:bg-pca-green-700 data-checked:focus:ring-pca-green-300"
         data-unchecked=""
-        id="base-ui-_r_a_"
+        id="base-ui-_r_f_"
         role="switch"
         tabindex="0"
       >
@@ -212,7 +212,7 @@ exports[`renders hint text 1`] = `
       <input
         aria-hidden="true"
         id="test"
-        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
         tabindex="-1"
         type="checkbox"
       />
@@ -260,7 +260,7 @@ exports[`renders with label 1`] = `
       <input
         aria-hidden="true"
         id="test"
-        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
         tabindex="-1"
         type="checkbox"
       />

--- a/app/ui/switch/__snapshots__/switch.test.tsx.snap
+++ b/app/ui/switch/__snapshots__/switch.test.tsx.snap
@@ -1,0 +1,277 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renders checked state 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-2"
+  >
+    <div
+      class="flex gap-2"
+    >
+      <span
+        aria-checked="true"
+        aria-invalid="false"
+        aria-labelledby="test-label"
+        class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-pointer bg-pca-grey-400 dark:bg-pca-grey-600 hover:bg-pca-grey-600 dark:hover:bg-pca-grey-800 focus:bg-pca-grey-300 dark:focus:bg-pca-grey-700 focus:ring-2 focus:ring-pca-grey-200 dark:focus:ring-pca-grey-500 data-checked:bg-pca-green-700 data-checked:hover:bg-pca-green-900 data-checked:focus:bg-pca-green-700 data-checked:focus:ring-pca-green-300"
+        data-checked=""
+        id="base-ui-_r_2_"
+        role="switch"
+        tabindex="0"
+      >
+        <span
+          class="block size-5 rounded-full shadow-primary transition-transform duration-200 ease-in-out data-checked:translate-x-5 bg-pca-white"
+          data-checked=""
+        />
+      </span>
+      <input
+        aria-hidden="true"
+        checked=""
+        id="test"
+        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        tabindex="-1"
+        type="checkbox"
+      />
+      <label
+        class="antialiased font-inter text-sm text-pca-grey-900 dark:text-pca-grey-300 font-semibold py-0.5 select-none cursor-pointer"
+        for="test"
+        id="test-label"
+      >
+        Test Label
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders disabled checked state 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-2"
+  >
+    <div
+      class="flex gap-2"
+    >
+      <span
+        aria-checked="true"
+        aria-disabled="true"
+        aria-invalid="false"
+        aria-labelledby="test-label"
+        class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-not-allowed bg-pca-grey-100 dark:bg-pca-grey-800 data-checked:bg-pca-green-100"
+        data-checked=""
+        data-disabled=""
+        id="base-ui-_r_6_"
+        role="switch"
+        tabindex="-1"
+      >
+        <span
+          class="block size-5 rounded-full shadow-primary transition-transform duration-200 ease-in-out data-checked:translate-x-5 bg-pca-grey-100 dark:bg-pca-grey-700 data-checked:bg-pca-white"
+          data-checked=""
+          data-disabled=""
+        />
+      </span>
+      <input
+        aria-hidden="true"
+        checked=""
+        disabled=""
+        id="test"
+        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        tabindex="-1"
+        type="checkbox"
+      />
+      <label
+        class="antialiased font-inter text-sm text-pca-grey-300 dark:text-pca-grey-800 font-semibold py-0.5 select-none pointer-events-none"
+        for="test"
+        id="test-label"
+      >
+        Test Label
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders disabled state 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-2"
+  >
+    <div
+      class="flex gap-2"
+    >
+      <span
+        aria-checked="false"
+        aria-disabled="true"
+        aria-invalid="false"
+        aria-labelledby="test-label"
+        class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-not-allowed bg-pca-grey-100 dark:bg-pca-grey-800 data-checked:bg-pca-green-100"
+        data-disabled=""
+        data-unchecked=""
+        id="base-ui-_r_4_"
+        role="switch"
+        tabindex="-1"
+      >
+        <span
+          class="block size-5 rounded-full shadow-primary transition-transform duration-200 ease-in-out data-checked:translate-x-5 bg-pca-grey-100 dark:bg-pca-grey-700 data-checked:bg-pca-white"
+          data-disabled=""
+          data-unchecked=""
+        />
+      </span>
+      <input
+        aria-hidden="true"
+        disabled=""
+        id="test"
+        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        tabindex="-1"
+        type="checkbox"
+      />
+      <label
+        class="antialiased font-inter text-sm text-pca-grey-300 dark:text-pca-grey-800 font-semibold py-0.5 select-none pointer-events-none"
+        for="test"
+        id="test-label"
+      >
+        Test Label
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders error state 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-2"
+  >
+    <div
+      class="flex gap-2"
+    >
+      <span
+        aria-checked="false"
+        aria-errormessage="test-error"
+        aria-invalid="true"
+        aria-labelledby="test-label"
+        class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-pointer bg-pca-grey-400 dark:bg-pca-grey-600 hover:bg-pca-grey-600 dark:hover:bg-pca-grey-800 focus:bg-pca-grey-300 dark:focus:bg-pca-grey-700 focus:ring-2 focus:ring-pca-grey-200 dark:focus:ring-pca-grey-500 data-checked:bg-pca-green-700 data-checked:hover:bg-pca-green-900 data-checked:focus:bg-pca-green-700 data-checked:focus:ring-pca-green-300"
+        data-unchecked=""
+        id="base-ui-_r_8_"
+        role="switch"
+        tabindex="0"
+      >
+        <span
+          class="block size-5 rounded-full shadow-primary transition-transform duration-200 ease-in-out data-checked:translate-x-5 bg-pca-white"
+          data-unchecked=""
+        />
+      </span>
+      <input
+        aria-hidden="true"
+        id="test"
+        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        tabindex="-1"
+        type="checkbox"
+      />
+      <label
+        class="antialiased font-inter text-sm text-pca-grey-900 dark:text-pca-grey-300 font-semibold py-0.5 select-none cursor-pointer"
+        for="test"
+        id="test-label"
+      >
+        Test Label
+      </label>
+    </div>
+    <span
+      class="antialiased font-inter text-xs font-normal text-pca-red-500 dark:text-pca-red-500"
+      id="test-error"
+    >
+      Error message
+    </span>
+  </div>
+</div>
+`;
+
+exports[`renders hint text 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-2"
+  >
+    <div
+      class="flex gap-2"
+    >
+      <span
+        aria-checked="false"
+        aria-describedby="test-hint"
+        aria-invalid="false"
+        aria-labelledby="test-label"
+        class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-pointer bg-pca-grey-400 dark:bg-pca-grey-600 hover:bg-pca-grey-600 dark:hover:bg-pca-grey-800 focus:bg-pca-grey-300 dark:focus:bg-pca-grey-700 focus:ring-2 focus:ring-pca-grey-200 dark:focus:ring-pca-grey-500 data-checked:bg-pca-green-700 data-checked:hover:bg-pca-green-900 data-checked:focus:bg-pca-green-700 data-checked:focus:ring-pca-green-300"
+        data-unchecked=""
+        id="base-ui-_r_a_"
+        role="switch"
+        tabindex="0"
+      >
+        <span
+          class="block size-5 rounded-full shadow-primary transition-transform duration-200 ease-in-out data-checked:translate-x-5 bg-pca-white"
+          data-unchecked=""
+        />
+      </span>
+      <input
+        aria-hidden="true"
+        id="test"
+        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        tabindex="-1"
+        type="checkbox"
+      />
+      <label
+        class="antialiased font-inter text-sm text-pca-grey-900 dark:text-pca-grey-300 font-semibold py-0.5 select-none cursor-pointer"
+        for="test"
+        id="test-label"
+      >
+        Test Label
+      </label>
+    </div>
+    <span
+      class="antialiased font-inter text-xs font-normal text-pca-grey-900 dark:text-white"
+      id="test-hint"
+    >
+      Hint text
+    </span>
+  </div>
+</div>
+`;
+
+exports[`renders with label 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-2"
+  >
+    <div
+      class="flex gap-2"
+    >
+      <span
+        aria-checked="false"
+        aria-invalid="false"
+        aria-labelledby="test-label"
+        class="relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out cursor-pointer bg-pca-grey-400 dark:bg-pca-grey-600 hover:bg-pca-grey-600 dark:hover:bg-pca-grey-800 focus:bg-pca-grey-300 dark:focus:bg-pca-grey-700 focus:ring-2 focus:ring-pca-grey-200 dark:focus:ring-pca-grey-500 data-checked:bg-pca-green-700 data-checked:hover:bg-pca-green-900 data-checked:focus:bg-pca-green-700 data-checked:focus:ring-pca-green-300"
+        data-unchecked=""
+        id="base-ui-_r_0_"
+        role="switch"
+        tabindex="0"
+      >
+        <span
+          class="block size-5 rounded-full shadow-primary transition-transform duration-200 ease-in-out data-checked:translate-x-5 bg-pca-white"
+          data-unchecked=""
+        />
+      </span>
+      <input
+        aria-hidden="true"
+        id="test"
+        style="overflow: hidden; white-space: nowrap; position: fixed; top: 0px; left: 0px; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px;"
+        tabindex="-1"
+        type="checkbox"
+      />
+      <label
+        class="antialiased font-inter text-sm text-pca-grey-900 dark:text-pca-grey-300 font-semibold py-0.5 select-none cursor-pointer"
+        for="test"
+        id="test-label"
+      >
+        Test Label
+      </label>
+    </div>
+  </div>
+</div>
+`;

--- a/app/ui/switch/switch.stories.tsx
+++ b/app/ui/switch/switch.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Switch } from './switch';
+
+/**
+ * Switch component for toggling a boolean setting.
+ *
+ * Built on the [Base UI Switch](https://base-ui.com/react/components/switch),
+ * which provides the `role="switch"` element, the hidden checkbox input for
+ * form submission, and the `data-checked` / `data-unchecked` / `data-disabled`
+ * attributes this component styles against.
+ */
+const meta: Meta<typeof Switch> = {
+  title: 'Forms/Switch',
+  component: Switch,
+};
+
+export default meta;
+type Story = StoryObj<typeof Switch>;
+
+export const Controlled: Story = {
+  render: (args) => {
+    // eslint-disable-next-line @eslint-react/rules-of-hooks
+    const [checked, setChecked] = useState(false);
+    return (
+      <Switch
+        {...args}
+        checked={checked}
+        onCheckedChange={setChecked}
+      />
+    );
+  },
+  args: {
+    id: 'link-sharing',
+    label: 'Link sharing',
+  },
+};
+
+export const Unchecked: Story = {
+  args: {
+    id: 'link-sharing',
+    label: 'Link sharing',
+    checked: false,
+  },
+};
+
+export const Checked: Story = {
+  args: {
+    id: 'link-sharing',
+    label: 'Link sharing',
+    checked: true,
+  },
+};
+
+export const WithoutLabel: Story = {
+  args: {
+    'id': 'link-sharing',
+    'aria-label': 'Link sharing',
+    'checked': true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    id: 'link-sharing',
+    label: 'Link sharing',
+    disabled: true,
+    checked: false,
+  },
+};
+
+export const DisabledChecked: Story = {
+  args: {
+    id: 'link-sharing',
+    label: 'Link sharing',
+    disabled: true,
+    checked: true,
+  },
+};
+
+export const WithHint: Story = {
+  args: {
+    id: 'link-sharing',
+    label: 'Link sharing',
+    hint: 'Anyone with the link will be able to view this document.',
+    checked: false,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    id: 'link-sharing',
+    label: 'Link sharing',
+    errorMessage: 'Link sharing could not be enabled',
+    checked: false,
+  },
+};

--- a/app/ui/switch/switch.test.tsx
+++ b/app/ui/switch/switch.test.tsx
@@ -1,0 +1,142 @@
+import { expect, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Switch } from './switch';
+
+test('renders with label', () => {
+  const { container } = render(
+    <Switch id="test" label="Test Label" />,
+  );
+
+  expect(container).toMatchSnapshot();
+});
+
+test('renders checked state', () => {
+  const { container } = render(
+    <Switch id="test" label="Test Label" checked />,
+  );
+
+  expect(container).toMatchSnapshot();
+});
+
+test('renders disabled state', () => {
+  const { container } = render(
+    <Switch id="test" label="Test Label" disabled />,
+  );
+
+  expect(container).toMatchSnapshot();
+});
+
+test('renders disabled checked state', () => {
+  const { container } = render(
+    <Switch id="test" label="Test Label" disabled checked />,
+  );
+
+  expect(container).toMatchSnapshot();
+});
+
+test('renders error state', () => {
+  const { container } = render(
+    <Switch id="test" label="Test Label" errorMessage="Error message" />,
+  );
+
+  expect(container).toMatchSnapshot();
+});
+
+test('renders hint text', () => {
+  const { container } = render(
+    <Switch id="test" label="Test Label" hint="Hint text" />,
+  );
+
+  expect(container).toMatchSnapshot();
+});
+
+test('exposes the label as the accessible name', () => {
+  render(<Switch id="test" label="Test Label" />);
+
+  expect(screen.getByRole('switch', { name: 'Test Label' }))
+    .toBeInTheDocument();
+});
+
+test('reflects the checked state to assistive technology', () => {
+  render(<Switch id="test" label="Test Label" checked />);
+
+  expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+});
+
+test('calls onCheckedChange when toggled', async () => {
+  const user = userEvent.setup();
+  const onCheckedChange = vi.fn();
+
+  render(
+    <Switch id="test" label="Test Label" onCheckedChange={onCheckedChange} />,
+  );
+
+  await user.click(screen.getByRole('switch'));
+
+  expect(onCheckedChange).toHaveBeenCalledWith(true, expect.anything());
+});
+
+test('toggles when the label is clicked', async () => {
+  const user = userEvent.setup();
+  const onCheckedChange = vi.fn();
+
+  render(
+    <Switch id="test" label="Test Label" onCheckedChange={onCheckedChange} />,
+  );
+
+  await user.click(screen.getByText('Test Label'));
+
+  expect(onCheckedChange).toHaveBeenCalledWith(true, expect.anything());
+});
+
+test('does not call onCheckedChange when disabled', async () => {
+  const user = userEvent.setup();
+  const onCheckedChange = vi.fn();
+
+  render(
+    <Switch
+      id="test"
+      label="Test Label"
+      disabled
+      onCheckedChange={onCheckedChange}
+    />,
+  );
+
+  await user.click(screen.getByRole('switch'));
+
+  expect(onCheckedChange).not.toHaveBeenCalled();
+});
+
+test('links the error message to the switch', () => {
+  render(
+    <Switch id="test" label="Test Label" errorMessage="Error message" />,
+  );
+
+  const element = screen.getByRole('switch');
+
+  expect(element).toHaveAttribute('aria-invalid', 'true');
+  expect(element).toHaveAttribute('aria-errormessage', 'test-error');
+  expect(screen.getByText('Error message')).toHaveAttribute('id', 'test-error');
+});
+
+test('links the hint to the switch', () => {
+  render(<Switch id="test" label="Test Label" hint="Hint text" />);
+
+  expect(screen.getByRole('switch'))
+    .toHaveAttribute('aria-describedby', 'test-hint');
+  expect(screen.getByText('Hint text')).toHaveAttribute('id', 'test-hint');
+});
+
+test('hides the hint when an error message is present', () => {
+  render(
+    <Switch
+      id="test"
+      label="Test Label"
+      hint="Hint text"
+      errorMessage="Error message"
+    />,
+  );
+
+  expect(screen.queryByText('Hint text')).not.toBeInTheDocument();
+});

--- a/app/ui/switch/switch.tsx
+++ b/app/ui/switch/switch.tsx
@@ -1,4 +1,4 @@
-import { Switch as BaseSwitch } from '@base-ui-components/react/switch';
+import { Switch as BaseSwitch } from '@base-ui/react/switch';
 import classNames from 'classnames';
 import { Label } from '../label/label';
 import { Typography } from '../typography/typography';

--- a/app/ui/switch/switch.tsx
+++ b/app/ui/switch/switch.tsx
@@ -1,0 +1,121 @@
+import { Switch as BaseSwitch } from '@base-ui-components/react/switch';
+import classNames from 'classnames';
+import { Label } from '../label/label';
+import { Typography } from '../typography/typography';
+
+export interface SwitchProps extends Pick<React.AriaAttributes, 'aria-label'> {
+  id: string;
+  name?: string;
+  /** Visible label. Use `aria-label` instead when the design has no label. */
+  label?: string;
+  hint?: string;
+  errorMessage?: string;
+  checked?: boolean;
+  defaultChecked?: boolean;
+  disabled?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  onBlur?: (event: React.FocusEvent<HTMLSpanElement>) => void;
+  className?: string;
+};
+
+export const Switch: React.FC<SwitchProps>
+  = ({
+    id,
+    name,
+    label,
+    'aria-label': ariaLabel,
+    hint,
+    errorMessage,
+    checked,
+    defaultChecked,
+    disabled,
+    onCheckedChange,
+    onBlur,
+    className,
+  }) => {
+    const trackClasses = classNames([
+      // Base styles
+      'relative inline-flex h-6 w-11 shrink-0 rounded-full p-0.5 outline-0 transition-colors duration-200 ease-in-out',
+      // Disabled state
+      disabled
+      && 'cursor-not-allowed bg-pca-grey-100 dark:bg-pca-grey-800 data-checked:bg-pca-green-100',
+      // Unchecked state
+      !disabled
+      && 'cursor-pointer bg-pca-grey-400 dark:bg-pca-grey-600 hover:bg-pca-grey-600 dark:hover:bg-pca-grey-800 focus:bg-pca-grey-300 dark:focus:bg-pca-grey-700 focus:ring-2 focus:ring-pca-grey-200 dark:focus:ring-pca-grey-500',
+      // Checked state
+      !disabled
+      && 'data-checked:bg-pca-green-700 data-checked:hover:bg-pca-green-900 data-checked:focus:bg-pca-green-700 data-checked:focus:ring-pca-green-300',
+    ]);
+
+    const thumbClasses = classNames([
+      // Base styles
+      'block size-5 rounded-full shadow-primary transition-transform duration-200 ease-in-out',
+      // Checked state
+      'data-checked:translate-x-5',
+      // Disabled state
+      disabled
+      && 'bg-pca-grey-100 dark:bg-pca-grey-700 data-checked:bg-pca-white',
+      !disabled && 'bg-pca-white',
+    ]);
+
+    return (
+      <div className={classNames('flex flex-col gap-2', className)}>
+        <div className="flex gap-2">
+          <BaseSwitch.Root
+            id={id}
+            name={name}
+            checked={checked}
+            defaultChecked={defaultChecked}
+            disabled={disabled}
+            onCheckedChange={onCheckedChange}
+            onBlur={onBlur}
+            aria-invalid={!!errorMessage}
+            aria-errormessage={errorMessage ? `${id}-error` : undefined}
+            aria-describedby={hint && !errorMessage ? `${id}-hint` : undefined}
+            // The hidden `<input>` that `htmlFor` targets is `aria-hidden`, so
+            // the label has to name the `role="switch"` element explicitly.
+            aria-labelledby={label ? `${id}-label` : undefined}
+            aria-label={ariaLabel}
+            className={trackClasses}
+          >
+            <BaseSwitch.Thumb className={thumbClasses} />
+          </BaseSwitch.Root>
+          {label && (
+            <Label
+              id={`${id}-label`}
+              htmlFor={id}
+              disabled={disabled}
+              className={classNames(
+                'py-0.5 select-none',
+                disabled ? 'pointer-events-none' : 'cursor-pointer',
+              )}
+            >
+              {label}
+            </Label>
+          )}
+        </div>
+        {hint && !errorMessage && (
+          <Typography
+            id={`${id}-hint`}
+            as="span"
+            variant="bodyTiny"
+            textColorLight="grey-900"
+            textColorDark="white"
+          >
+            {hint}
+          </Typography>
+        )}
+        {errorMessage && (
+          <Typography
+            id={`${id}-error`}
+            as="span"
+            variant="bodyTiny"
+            textColorLight="red-500"
+            textColorDark="red-500"
+          >
+            {errorMessage}
+          </Typography>
+        )}
+      </div>
+    );
+  };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "app",
       "dependencies": {
-        "@base-ui-components/react": "^1.0.0-rc.0",
+        "@base-ui/react": "^1.7.0",
         "@fontsource/inter": "^5.3.0",
         "@hocuspocus/extension-database": "^4.5.0",
         "@hocuspocus/provider": "^4.5.0",
@@ -565,19 +565,16 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@base-ui-components/react": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-rc.0.tgz",
-      "integrity": "sha512-9lhUFbJcbXvc9KulLev1WTFxS/alJRBWDH/ibKSQaNvmDwMFS2gKp1sTeeldYSfKuS/KC1w2MZutc0wHu2hRHQ==",
-      "deprecated": "Package was renamed to @base-ui/react",
+    "node_modules/@base-ui/react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+      "integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@base-ui-components/utils": "0.2.2",
-        "@floating-ui/react-dom": "^2.1.6",
-        "@floating-ui/utils": "^0.2.10",
-        "reselect": "^5.1.1",
-        "tabbable": "^6.3.0",
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.3.2",
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
         "use-sync-external-store": "^1.6.0"
       },
       "engines": {
@@ -588,26 +585,33 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
         "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
         "react": "^17 || ^18 || ^19",
         "react-dom": "^17 || ^18 || ^19"
       },
       "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
         "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
           "optional": true
         }
       }
     },
-    "node_modules/@base-ui-components/utils": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@base-ui-components/utils/-/utils-0.2.2.tgz",
-      "integrity": "sha512-rNJCD6TFy3OSRDKVHJDzLpxO3esTV1/drRtWNUpe7rCpPN9HZVHUCuP+6rdDYDGWfXnQHbqi05xOyRP2iZAlkw==",
-      "deprecated": "Package was renamed to @base-ui/utils",
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+      "integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@floating-ui/utils": "^0.2.10",
-        "reselect": "^5.1.1",
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.12",
+        "reselect": "^5.2.0",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -1407,20 +1411,22 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/react": {
@@ -1438,11 +1444,12 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
+        "@floating-ui/dom": "^1.8.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1450,9 +1457,10 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
     },
     "node_modules/@fontsource/inter": {
       "version": "5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "app",
       "dependencies": {
+        "@base-ui-components/react": "^1.0.0-rc.0",
         "@fontsource/inter": "^5.3.0",
         "@hocuspocus/extension-database": "^4.5.0",
         "@hocuspocus/provider": "^4.5.0",
@@ -562,6 +563,62 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui-components/react": {
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-rc.0.tgz",
+      "integrity": "sha512-9lhUFbJcbXvc9KulLev1WTFxS/alJRBWDH/ibKSQaNvmDwMFS2gKp1sTeeldYSfKuS/KC1w2MZutc0wHu2hRHQ==",
+      "deprecated": "Package was renamed to @base-ui/react",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@base-ui-components/utils": "0.2.2",
+        "@floating-ui/react-dom": "^2.1.6",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
+        "tabbable": "^6.3.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui-components/utils": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@base-ui-components/utils/-/utils-0.2.2.tgz",
+      "integrity": "sha512-rNJCD6TFy3OSRDKVHJDzLpxO3esTV1/drRtWNUpe7rCpPN9HZVHUCuP+6rdDYDGWfXnQHbqi05xOyRP2iZAlkw==",
+      "deprecated": "Package was renamed to @base-ui/utils",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@clevercloud/client": {
@@ -11338,6 +11395,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@base-ui-components/react": "^1.0.0-rc.0",
     "@fontsource/inter": "^5.3.0",
     "@hocuspocus/extension-database": "^4.5.0",
     "@hocuspocus/provider": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@base-ui-components/react": "^1.0.0-rc.0",
+    "@base-ui/react": "^1.7.0",
     "@fontsource/inter": "^5.3.0",
     "@hocuspocus/extension-database": "^4.5.0",
     "@hocuspocus/provider": "^4.5.0",


### PR DESCRIPTION
Adds a `Switch` to the design system, built on the [Base UI Switch](https://base-ui.com/react/components/switch) and styled with Tailwind + the `pca-*` tokens. All eight states from the designs are covered in light and dark mode — default, hover, focus and disabled, each on and off.

`ControlledSwitch` wires it to TanStack Form and is registered as `Switch` in the field registry, so it's available as `<field.Switch />`.

### ⚠️ This changes tooltips

`tooltip.tsx` already used the `shadow-primary` class, but no such token was defined, so it silently did nothing. The designs define it, so it's now in the theme — meaning **tooltips pick up the drop shadow they were always meant to have**. It looks right, but it's a visual change outside this component. Happy to scope it to the switch instead if you'd prefer.

### `Label` gained an optional `id` prop

Base UI renders the switch as a `<span role="switch">` beside an `aria-hidden` input, so `htmlFor` alone makes clicking work but leaves the switch with no accessible name. The label now takes an `id` that the switch points at via `aria-labelledby`. Additive, no existing snapshots moved.

Also adds `--color-pca-green-100`, needed by the disabled-on state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)