### PR TITLE
feat(ui): copy link button

### DIFF
--- a/app/ui/copy-link-button/__snapshots__/copy-link-button.test.tsx.snap
+++ b/app/ui/copy-link-button/__snapshots__/copy-link-button.test.tsx.snap
@@ -1,0 +1,101 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CopyLinkButton > snapshots > copied state 1`] = `
+<div>
+  <button
+    aria-live="polite"
+    class="relative overflow-hidden active:scale-[0.97] flex items-center justify-center gap-2 transition-all duration-300 ease-in-out h-9 rounded-xl px-3 py-2 flex-row-reverse text-pca-white bg-pca-grey-900 hover:bg-pca-grey-800 focus:outline-hidden focus:ring-2 focus:ring-pca-grey-300 active:bg-pca-grey-800 dark:text-pca-grey-900 dark:bg-pca-white dark:hover:bg-pca-grey-300 dark:focus:outline-hidden dark:focus:ring-2 dark:focus:ring-pca-grey-300 dark:active:bg-pca-grey-300"
+  >
+    <span
+      class="antialiased font-inter text-sm text-pca-grey-900 dark:text-white font-medium text-inherit! leading-none"
+    >
+      Link copied!
+    </span>
+    <svg
+      aria-hidden="true"
+      class="shrink-0 w-4.5 h-4.5"
+      fill="transparent"
+      focusable="false"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7.5 12L10.5 15L16.5 9M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.5"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`CopyLinkButton > snapshots > default state 1`] = `
+<div>
+  <button
+    aria-live="polite"
+    class="relative overflow-hidden active:scale-[0.97] flex items-center justify-center gap-2 transition-all duration-300 ease-in-out h-9 rounded-xl px-3 py-2 flex-row-reverse text-pca-white bg-pca-grey-900 hover:bg-pca-grey-800 focus:outline-hidden focus:ring-2 focus:ring-pca-grey-300 active:bg-pca-grey-800 dark:text-pca-grey-900 dark:bg-pca-white dark:hover:bg-pca-grey-300 dark:focus:outline-hidden dark:focus:ring-2 dark:focus:ring-pca-grey-300 dark:active:bg-pca-grey-300"
+  >
+    <span
+      class="antialiased font-inter text-sm text-pca-grey-900 dark:text-white font-medium text-inherit! leading-none"
+    >
+      Copy link
+    </span>
+    <svg
+      aria-hidden="true"
+      class="shrink-0 w-4.5 h-4.5"
+      fill="transparent"
+      focusable="false"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 17H7C4.23858 17 2 14.7614 2 12C2 9.23858 4.23858 7 7 7H9M15 17H17C19.7614 17 22 14.7614 22 12C22 9.23858 19.7614 7 17 7H15M7 12H17"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.5"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`CopyLinkButton > snapshots > disabled state 1`] = `
+<div>
+  <button
+    aria-live="polite"
+    class="relative overflow-hidden active:scale-[0.97] flex items-center justify-center gap-2 transition-all duration-300 ease-in-out h-9 pointer-events-none rounded-xl px-3 py-2 flex-row-reverse text-pca-white bg-pca-grey-300 focus:outline-hidden dark:text-pca-grey-900 dark:bg-pca-grey-800 dark:text-pca-grey-700! dark:focus:outline-hidden"
+    disabled=""
+  >
+    <span
+      class="antialiased font-inter text-sm text-pca-grey-900 dark:text-white font-medium text-inherit! leading-none"
+    >
+      Copy link
+    </span>
+    <svg
+      aria-hidden="true"
+      class="shrink-0 w-4.5 h-4.5"
+      fill="transparent"
+      focusable="false"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 17H7C4.23858 17 2 14.7614 2 12C2 9.23858 4.23858 7 7 7H9M15 17H17C19.7614 17 22 14.7614 22 12C22 9.23858 19.7614 7 17 7H15M7 12H17"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.5"
+      />
+    </svg>
+  </button>
+</div>
+`;

--- a/app/ui/copy-link-button/copy-link-button.stories.tsx
+++ b/app/ui/copy-link-button/copy-link-button.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CopyLinkButton } from './copy-link-button';
+
+/**
+ * 🔗 The `CopyLinkButton` writes the given `link` to the clipboard and swaps
+ * to a confirmation state for `copiedDuration` milliseconds.
+ *
+ * All labels are props, so the copy stays in the app layer and never in the
+ * UI library.
+ */
+const meta: Meta<typeof CopyLinkButton> = {
+  title: 'Forms/CopyLinkButton',
+  component: CopyLinkButton,
+  args: {
+    link: 'https://pencilcase.app/doc/42',
+    label: 'Copy link',
+    copiedLabel: 'Link copied!',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CopyLinkButton>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/app/ui/copy-link-button/copy-link-button.test.tsx
+++ b/app/ui/copy-link-button/copy-link-button.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CopyLinkButton } from './copy-link-button';
+
+const link = 'https://pencilcase.app/doc/42';
+
+function renderButton(props: Partial<
+  React.ComponentProps<typeof CopyLinkButton>
+> = {}) {
+  /*
+   * `userEvent.setup()` installs a clipboard stub on the window, so it has to
+   * run before we spy on `writeText`.
+   */
+  const user = userEvent.setup();
+  const writeText = vi.spyOn(navigator.clipboard, 'writeText');
+
+  const result = render(
+    <CopyLinkButton
+      link={link}
+      label="Copy link"
+      copiedLabel="Link copied!"
+      {...props}
+    />,
+  );
+
+  return { ...result, user, writeText };
+}
+
+describe('CopyLinkButton', () => {
+  test('renders the given label', () => {
+    renderButton();
+
+    expect(
+      screen.getByRole('button', { name: 'Copy link' }),
+    ).toBeInTheDocument();
+  });
+
+  test('writes the link to the clipboard when clicked', async () => {
+    const { user, writeText } = renderButton();
+
+    await user.click(screen.getByRole('button'));
+
+    expect(writeText).toHaveBeenCalledExactlyOnceWith(link);
+  });
+
+  test('shows the copied label after copying', async () => {
+    const { user } = renderButton();
+
+    await user.click(screen.getByRole('button'));
+
+    expect(
+      await screen.findByRole('button', { name: 'Link copied!' }),
+    ).toBeInTheDocument();
+  });
+
+  test('calls onCopy with the link', async () => {
+    const onCopy = vi.fn();
+    const { user } = renderButton({ onCopy });
+
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(onCopy).toHaveBeenCalledExactlyOnceWith(link);
+    });
+  });
+
+  test('returns to the idle label after copiedDuration', async () => {
+    const { user } = renderButton({ copiedDuration: 10 });
+
+    await user.click(screen.getByRole('button'));
+    expect(
+      await screen.findByRole('button', { name: 'Link copied!' }),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Copy link' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('still calls a custom onClick handler', async () => {
+    const onClick = vi.fn();
+    const { user } = renderButton({ onClick });
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  test('does not copy when disabled', async () => {
+    const { user, writeText } = renderButton({ disabled: true });
+
+    expect(screen.getByRole('button')).toBeDisabled();
+
+    await user.click(screen.getByRole('button'));
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  describe('snapshots', () => {
+    test('default state', () => {
+      const { container } = renderButton();
+
+      expect(container).toMatchSnapshot();
+    });
+
+    test('copied state', async () => {
+      const { container, user } = renderButton();
+
+      await user.click(screen.getByRole('button'));
+      await screen.findByRole('button', { name: 'Link copied!' });
+
+      expect(container).toMatchSnapshot();
+    });
+
+    test('disabled state', () => {
+      const { container } = renderButton({ disabled: true });
+
+      expect(container).toMatchSnapshot();
+    });
+  });
+});

--- a/app/ui/copy-link-button/copy-link-button.tsx
+++ b/app/ui/copy-link-button/copy-link-button.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { Button, type ButtonProps } from '../button/button';
+
+export type CopyLinkButtonProps = {
+  /** The value written to the clipboard. */
+  link: string;
+  /** Label of the idle state, e.g. "Copy link". */
+  label: string;
+  /** Label shown right after copying, e.g. "Link copied!". */
+  copiedLabel: string;
+  /** How long the copied state stays visible, in milliseconds. */
+  copiedDuration?: number;
+  onCopy?: (link: string) => void;
+} & Omit<ButtonProps<'button'>, 'as' | 'children' | 'icon' | 'iconPosition'>;
+
+export const CopyLinkButton: React.FC<CopyLinkButtonProps> = ({
+  link,
+  label,
+  copiedLabel,
+  copiedDuration = 2000,
+  onCopy,
+  onClick,
+  ...props
+}) => {
+  const [isCopied, setIsCopied] = useState(false);
+
+  useEffect(() => {
+    if (!isCopied) {
+      return;
+    }
+
+    const timeout = setTimeout(() => setIsCopied(false), copiedDuration);
+
+    return () => clearTimeout(timeout);
+  }, [isCopied, copiedDuration]);
+
+  const copyToClipboard = async () => {
+    await navigator.clipboard.writeText(link);
+    setIsCopied(true);
+    onCopy?.(link);
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    void copyToClipboard();
+  };
+
+  return (
+    <Button
+      {...props}
+      onClick={handleClick}
+      icon={isCopied ? 'check' : 'link'}
+      iconPosition="start"
+      aria-live="polite"
+    >
+      {isCopied ? copiedLabel : label}
+    </Button>
+  );
+};

--- a/app/ui/copy-link-button/copy-link-button.tsx
+++ b/app/ui/copy-link-button/copy-link-button.tsx
@@ -42,7 +42,7 @@ export const CopyLinkButton: React.FC<CopyLinkButtonProps> = ({
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     onClick?.(event);
-    void copyToClipboard();
+    copyToClipboard();
   };
 
   return (

--- a/app/ui/icon/__snapshots__/icon.test.tsx.snap
+++ b/app/ui/icon/__snapshots__/icon.test.tsx.snap
@@ -515,7 +515,7 @@ exports[`Icon Component > should render with icon name 21`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M7.5 12L10.5 15L16.5 9M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+      d="M9 17H7C4.23858 17 2 14.7614 2 12C2 9.23858 4.23858 7 7 7H9M15 17H17C19.7614 17 22 14.7614 22 12C22 9.23858 19.7614 7 17 7H15M7 12H17"
       stroke="currentColor"
       stroke-linecap="round"
       stroke-linejoin="round"
@@ -538,7 +538,7 @@ exports[`Icon Component > should render with icon name 22`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M11.9998 8.99999V13M11.9998 17H12.0098M10.6151 3.89171L2.39019 18.0983C1.93398 18.8863 1.70588 19.2803 1.73959 19.6037C1.769 19.8857 1.91677 20.142 2.14613 20.3088C2.40908 20.5 2.86435 20.5 3.77487 20.5H20.2246C21.1352 20.5 21.5904 20.5 21.8534 20.3088C22.0827 20.142 22.2305 19.8857 22.2599 19.6037C22.2936 19.2803 22.0655 18.8863 21.6093 18.0983L13.3844 3.89171C12.9299 3.10654 12.7026 2.71396 12.4061 2.58211C12.1474 2.4671 11.8521 2.4671 11.5935 2.58211C11.2969 2.71396 11.0696 3.10655 10.6151 3.89171Z"
+      d="M7.5 12L10.5 15L16.5 9M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
       stroke="currentColor"
       stroke-linecap="round"
       stroke-linejoin="round"
@@ -549,6 +549,29 @@ exports[`Icon Component > should render with icon name 22`] = `
 `;
 
 exports[`Icon Component > should render with icon name 23`] = `
+<div>
+  <svg
+    aria-hidden="true"
+    class=""
+    fill="transparent"
+    focusable="false"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M11.9998 8.99999V13M11.9998 17H12.0098M10.6151 3.89171L2.39019 18.0983C1.93398 18.8863 1.70588 19.2803 1.73959 19.6037C1.769 19.8857 1.91677 20.142 2.14613 20.3088C2.40908 20.5 2.86435 20.5 3.77487 20.5H20.2246C21.1352 20.5 21.5904 20.5 21.8534 20.3088C22.0827 20.142 22.2305 19.8857 22.2599 19.6037C22.2936 19.2803 22.0655 18.8863 21.6093 18.0983L13.3844 3.89171C12.9299 3.10654 12.7026 2.71396 12.4061 2.58211C12.1474 2.4671 11.8521 2.4671 11.5935 2.58211C11.2969 2.71396 11.0696 3.10655 10.6151 3.89171Z"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.5"
+    />
+  </svg>
+</div>
+`;
+
+exports[`Icon Component > should render with icon name 24`] = `
 <div>
   <svg
     aria-hidden="true"

--- a/app/ui/icon/icons.tsx
+++ b/app/ui/icon/icons.tsx
@@ -19,6 +19,7 @@ export type IconName
     | 'search'
     | 'settings'
     | 'info'
+    | 'link'
     | 'check'
     | 'danger'
     | 'warning'
@@ -213,6 +214,15 @@ export const icons: {
   'info': (
     <path
       d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  ),
+  'link': (
+    <path
+      d="M9 17H7C4.23858 17 2 14.7614 2 12C2 9.23858 4.23858 7 7 7H9M15 17H17C19.7614 17 22 14.7614 22 12C22 9.23858 19.7614 7 17 7H15M7 12H17"
       stroke="currentColor"
       strokeWidth="1.5"
       strokeLinecap="round"


### PR DESCRIPTION
Copy-link button from Figma: [default](https://www.figma.com/design/9CoFD3RmvJCYgsIFdY1mwp/pencilcase-app?node-id=2260-11565) · [copied](https://www.figma.com/design/9CoFD3RmvJCYgsIFdY1mwp/pencilcase-app?node-id=2260-11697) · [disabled](https://www.figma.com/design/9CoFD3RmvJCYgsIFdY1mwp/pencilcase-app?node-id=2260-11519)

`CopyLinkButton` wraps the existing `Button`, copies `link` to the clipboard on click, and shows `copiedLabel` for `copiedDuration` (default 2s) before resetting. Both labels are required props, so no copy lives in the UI library. Adds the `link` glyph to the icon registry.

Includes Storybook stories and unit tests.

Notes:
- A failed clipboard write is deliberately not handled yet.
- Label weight and disabled background differ slightly from the mocks — both come from `Button` and would affect every button in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)